### PR TITLE
Viser alltid inneværende år i copyright-footeren

### DIFF
--- a/frontend/content/index.html
+++ b/frontend/content/index.html
@@ -143,7 +143,7 @@
     <footer class="clear hide"><div class="outer"><div class="inner">
         <ul>
             <li>Digipost Labs er en nettside fra Posten Norge AS</li>
-            <li>Posten Norge AS &copy; 2011-2013</li>
+            <li>Posten Norge AS &copy; 2011-<%= new Date().getFullYear() %></li>
             <li>Innhold lisensiert under <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank">CC-BY-SA 3.0</a></li>
             <li><strong>Ansvarlig redaktør:</strong> <a href="#!/profiles/529f1073e4b01d76f220b013">Thomas Mathisen</a></li>
         </ul>


### PR DESCRIPTION
Bruker `new Date().getFullYear()` for å alltid vise inneværende år som siste år i copyright-footeren.